### PR TITLE
Ajuste para exibir também dados de campos novos do EOL ao abrir um formulário.

### DIFF
--- a/sme_atualizacao_cadastral_apps/eol_servico/utils.py
+++ b/sme_atualizacao_cadastral_apps/eol_servico/utils.py
@@ -178,6 +178,10 @@ class EOLService(object):
         dados_responsavel = dados['responsaveis'][0]
         status = "ATUALIZADO_EOL" if not EOLService.tem_informacao_faltando(dados_responsavel) else 'DESATUALIZADO'
 
+        data_nascimento_responsavel = datetime.datetime.strptime(dados['responsaveis'][0][
+                'dt_nascimento_responsavel'].strip(), '%Y-%m-%dT%H:%M:%S') if dados['responsaveis'][0][
+                'dt_nascimento_responsavel']  else None
+
         responsavel = Responsavel.objects.create(
             vinculo=dados['responsaveis'][0]['tp_pessoa_responsavel'],
             codigo_eol_aluno=codigo_eol,
@@ -187,6 +191,9 @@ class EOLService(object):
             ddd_celular=dados['responsaveis'][0]['cd_ddd_celular_responsavel'].strip() if dados['responsaveis'][0][
                 'cd_ddd_celular_responsavel'] else None,
             celular=dados['responsaveis'][0]['nr_celular_responsavel'],
+            nome_mae=dados['responsaveis'][0]['nm_mae_responsavel'].strip() if dados['responsaveis'][0][
+                'nm_mae_responsavel'] else None,
+            data_nascimento=data_nascimento_responsavel,
             status=status
         )
         aluno = Aluno.objects.create(


### PR DESCRIPTION
Esse PR contém:

* Foi ajustado apenas o back para a criação do aluno/responsável no adm-escola já que no cadastro de responsável não foi preciso.